### PR TITLE
Check that var "labels" is not of type NoneType...

### DIFF
--- a/deck_chores/main.py
+++ b/deck_chores/main.py
@@ -32,7 +32,7 @@ def there_is_another_deck_chores_container() -> bool:
         if container['State'] in 'created,exited':
             continue
         labels = get_image_labels_for_container(container['Id'])
-        if labels.get('org.label-schema.name', '') == 'deck-chores':
+        if (labels and labels.get('org.label-schema.name', '') == 'deck-chores'):
             matched_containers += 1
         if matched_containers > 1:
             return True


### PR DESCRIPTION
...while traversing other containers in context for deck-chores metadata.
Running tox fails the test in envs py35 and py36, could be about python3 on my machine?
I used a [native python 3.6 env](https://docs.python.org/3/library/venv.html) since I couldn't get pew to work either, on ubuntu 16.04.01.