### PR TITLE
use digest instead of tag for python:3.6-alpine base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-alpine
+FROM python@sha256:142fc3f338b10569d08c3f3855c492c2a176b0c45af099f9ebe87f0fededb210
 
 MAINTAINER Frank Sachsenheim <funkyfuture@riseup.net>
 

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,4 +1,4 @@
-FROM python:3.6-alpine
+FROM python@sha256:142fc3f338b10569d08c3f3855c492c2a176b0c45af099f9ebe87f0fededb210
 
 ENTRYPOINT ["/sbin/tini", "--"]
 CMD ["deck-chores"]


### PR DESCRIPTION
Digests are immutable and thus preferred over the use of tags.

Closes gh-9.