### PR TITLE
update apk repo indexes instead of upgrading packages, pin tini's version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,6 @@ CMD ["deck-chores"]
 
 COPY . /src
 
-RUN apk upgrade --no-cache \
- && apk add --no-cache tini \
+RUN apk add --update --no-cache tini=0.9.0-r1 \
  && /src/setup.py install \
  && rm -Rf /root/.cache

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -5,7 +5,7 @@ CMD ["deck-chores"]
 LABEL org.label-schema.name="deck-chores"
 ENV DEBUG=true
 
-RUN apk add --no-cache tini \
+RUN apk add --update --no-cache tini=0.9.0-r1 \
  && pip install cerberus~=1.1 docker-py fasteners APScheduler
 
 COPY . /src


### PR DESCRIPTION


Upgrading system packages in an image's build easily leads to issues
within the image/containers that are started due to changes between
package versions. This patch updates the indexes instead of upgrading all
system packages, and pins the version for the `tini` dependency.

closes gh-11