### PR TITLE
fix check on locked services

### DIFF
--- a/deck_chores/main.py
+++ b/deck_chores/main.py
@@ -73,7 +73,7 @@ def process_running_container_labels(container_id: str) -> None:
     if not definitions:
         return
     if service_id and 'service' in options:
-        if locking_container_to_services_map.values():
+        if service_id in locking_container_to_services_map.values():
             log.debug('Service id has a registered job: %s' % service_id)
             return
         log.info('Locking service id: %s' % service_id)


### PR DESCRIPTION
Found this out from 59fb8bbc5d7516066934120fc92cc2680fd014e7 trying to run several containers on the same node, some of which had periodic tasks: adding the second service and restarting deck-chores registered jobs only for this service and ignored the previously deployed one.