### PR TITLE
change job name to container_id for better logs

### DIFF
--- a/deck_chores/jobs.py
+++ b/deck_chores/jobs.py
@@ -134,7 +134,7 @@ def add(
             ),
             kwargs=definition,
             id=job_id,
-            name=container_id,
+            name=job_name,
             max_instances=definition['max'],
             next_run_time=None if paused else undefined_runtime,
             replace_existing=True,

--- a/deck_chores/jobs.py
+++ b/deck_chores/jobs.py
@@ -134,6 +134,7 @@ def add(
             ),
             kwargs=definition,
             id=job_id,
+            name=container_id,
             max_instances=definition['max'],
             next_run_time=None if paused else undefined_runtime,
             replace_existing=True,


### PR DESCRIPTION
should change:

 ```
Execution of job "exec_job (trigger: cron[year='*', month='*', day='*', week='*', day_of_week='*', hour='*', minute='30', second='0'], next run at: 2020-07-31 10:30:00 UTC)" skipped: maximum number of running instances reached (1)
```

to:

 ```
Execution of job "<job_name> (trigger: cron[year='*', month='*', day='*', week='*', day_of_week='*', hour='*', minute='30', second='0'], next run at: 2020-07-31 10:30:00 UTC)" skipped: maximum number of running instances reached (1)
```

see https://github.com/agronholm/apscheduler/blob/master/apscheduler/job.py#L171  
and https://github.com/agronholm/apscheduler/blob/master/apscheduler/job.py#L296

Edit: Could also potentially be `job_name` (or a mix of both) which would probably be more properate and better for debugging failed jobs.