### PR TITLE
Updated docs example for redirecting output to enable `docker logs` to work as normal

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -118,9 +118,12 @@ Making jobs' output available to ``docker logs`` of the executing container
 
 Docker captures the output of the first process in a container as logged data. In order to capture
 the output of a job's command as well, its output needs to be redirected to the main process'
-``stdout`` or ``stderr``, e.g. with by redirecting a command's output with a shell::
+``stdout`` and ``stderr``, e.g. by redirecting a command's output with a shell::
 
-    deck-chores.a_job.command: sh -c "/usr/local/bin/job_script.sh &> /proc/1/fd/1"
+    deck-chores.a_job.command: sh -c "/usr/local/bin/job_script.sh > /proc/1/fd/1 2> /proc/1/fd/2"
+
+It is important to redirect both ``stdout`` (``>``) AND ``stderr`` (``2>``) separately so 
+``docker logs`` will also separate the streams as normal.
 
 
 Listing all registered jobs

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -122,8 +122,10 @@ the output of a job's command as well, its output needs to be redirected to the 
 
     deck-chores.a_job.command: sh -c "/usr/local/bin/job_script.sh > /proc/1/fd/1 2> /proc/1/fd/2"
 
-It is important to redirect both ``stdout`` (``>``) AND ``stderr`` (``2>``) separately so 
-``docker logs`` will also separate the streams as normal.
+The normal behaviour of ``docker logs`` is that it separates ``stdout`` and ``stderr`` into 
+different streams for output. If you want to retain this behaviour, you must redirect 
+both ``stdout`` (``>``) and ``stderr`` (``2>``) separately as shown.
+
 
 
 Listing all registered jobs


### PR DESCRIPTION
Previous example was redirecting both `stdout` and `stderr` to PID 1's `stdout`.

The updated example maintains the separation of `stdout` and `stderr` into `docker logs`, where either stream can be redirected independently as per normal Docker behaviour. To output one of them, you redirect the stream you DON'T want:

Only show `stderr`:
`docker logs foo > /dev/null`

Only show `stdout`:
`docker logs foo 2>/dev/null`

Tests not run as this is a docs-only PR.