### PR TITLE
Date parsing quick fix

### DIFF
--- a/deck_chores/main.py
+++ b/deck_chores/main.py
@@ -100,7 +100,7 @@ def inspect_running_containers() -> datetime:
         started_at = cfg.client.api.inspect_container(container_id)['State'][
             'StartedAt'
         ]
-        date_string = (started_at[: 23 if len(started_at) < 26 else 26]).replace('Z', '00+00')
+        date_string = (started_at[: 23 if len(started_at) < 26 else 26]).replace('Z', '+00:00')
         last_event_time = max(
             last_event_time,
             datetime.fromisoformat(date_string),

--- a/deck_chores/main.py
+++ b/deck_chores/main.py
@@ -100,9 +100,10 @@ def inspect_running_containers() -> datetime:
         started_at = cfg.client.api.inspect_container(container_id)['State'][
             'StartedAt'
         ]
+        date_string = (started_at[: 23 if len(started_at) < 26 else 26]).replace('Z', '00+00')
         last_event_time = max(
             last_event_time,
-            datetime.fromisoformat(started_at[: 23 if len(started_at) < 26 else 26]),
+            datetime.fromisoformat(date_string),
         )
         process_started_container_labels(
             container_id, paused=container.status == 'paused'


### PR DESCRIPTION
This is an attempt to fix #70.

For the long-term, using the `dateutil` library to parse ISO dates [would be better](https://discuss.python.org/t/parse-z-timezone-suffix-in-datetime/2220). 
Unfortunately I can't set up the environment to make thorough tests easily.