### PR TITLE
Update parsers.py

### DIFF
--- a/deck_chores/parsers.py
+++ b/deck_chores/parsers.py
@@ -222,8 +222,11 @@ def parse_job_definitions(labels: Mapping[str, str], user: str) -> dict[str, dic
                 variable
             ] = value
         else:
-            name, attribute = key.split('.', 1)
-            name_grouped_definitions[name][attribute] = value
+            if '.' in key:
+                name, attribute = key.split('.', 1)
+                name_grouped_definitions[name][attribute] = value
+            else:
+                log.error(f'Misconfigured label definition: {key}')
 
     log.debug(f'Job definitions: {dict(name_grouped_definitions)}')
 


### PR DESCRIPTION
Hello again!

If the container-labels for a single service are omitted, the deck-chores service fails and dies:

```yml
[...]
    labels:
       deck-chores.command: "echo hello"
       deck-chores.interval: "hourly"
[...]
```

The trailing commit fixes the service failing on misconfigured/broken job label definitions, 
and prints an error instead.

Sorry for missing / failing tests.

Thanks!