### PR TITLE
Fix infinite loop when DEBUG=true

### DIFF
--- a/deck_chores/main.py
+++ b/deck_chores/main.py
@@ -277,7 +277,7 @@ def shutdown() -> None:  # pragma: nocover
 
 
 def main() -> None:  # pragma: nocover
-    if DEBUG and not __debug__:
+    if not DEBUG and __debug__:
         log.debug("Replacing process with Python's optimizations off.")
         sys.stdout.flush()
         os.execlpe("deck-chores", "deck-chores", {**os.environ, "PYTHONOPTIMIZE": "1"})


### PR DESCRIPTION
Currently if you run deck-chores with DEBUG=true, you get stuck in an infinite loop:

```bash
$ docker run --rm -it -v /var/run/docker.sock:/var/run/docker.sock -e DEBUG=true funkyfuture/deck-chores:1
Replacing process with Python's optimizations off.
Replacing process with Python's optimizations off.
Replacing process with Python's optimizations off.
Replacing process with Python's optimizations off.
Replacing process with Python's optimizations off.
Replacing process with Python's optimizations off.
Replacing process with Python's optimizations off.
Replacing process with Python's optimizations off.
Replacing process with Python's optimizations off.
^C
```

You only want to run with optimizations if
 - `DEBUG` is not set
 - `__debug__` is true (you're not already running with optimizations)